### PR TITLE
[FR-23] Change first launch loading behavior 

### DIFF
--- a/Modules/Data/DataInterface/Sources/DataInterface/Protocols/UserDefaultsDataSource.swift
+++ b/Modules/Data/DataInterface/Sources/DataInterface/Protocols/UserDefaultsDataSource.swift
@@ -9,4 +9,5 @@ import Foundation
 
 public protocol UserDefaultsDataSourceProtocol {
     var isCoreDataSynced: Bool { get set }
+    var isAppAlreadyHasFirstLaunch: Bool { get set }
 }

--- a/Modules/Data/LocalStores/Sources/LocalStores/CoreData/PersistenceController.swift
+++ b/Modules/Data/LocalStores/Sources/LocalStores/CoreData/PersistenceController.swift
@@ -7,17 +7,11 @@
 
 import Foundation
 import CoreData
-import Utilities
 import Logging
 
 public struct PersistenceController {
+    private let container: NSPersistentContainer
     public static let shared = PersistenceController()
-    public let container: NSPersistentContainer
-
-    @MainActor
-    public var mainViewContext: NSManagedObjectContext {
-        container.viewContext
-    }
 
     #if DEBUG
     // For test & previews

--- a/Modules/Data/LocalStores/Sources/LocalStores/UserDefaults/UserDefaultsDataSource.swift
+++ b/Modules/Data/LocalStores/Sources/LocalStores/UserDefaults/UserDefaultsDataSource.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 import DataInterface
-import Utilities
 import Logging
 
 public final class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
     private let userDefaults = UserDefaults.standard
-    private let coreDataKey = "is_core_data_synced"
+    private enum Keys {
+        static let coreDataKey = "is_core_data_synced"
+        static let launchKey = "is_app_already_has_first_launch"
+    }
 
     public init() {
         Logger.storage.info("\(String.logHeader()) Started")
@@ -23,7 +25,12 @@ public final class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
     }
 
     public var isCoreDataSynced: Bool {
-        get { userDefaults.bool(forKey: coreDataKey) }
-        set { userDefaults.set(newValue, forKey: coreDataKey) }
+        get { userDefaults.bool(forKey: Keys.coreDataKey) }
+        set { userDefaults.set(newValue, forKey: Keys.coreDataKey) }
+    }
+
+    public var isAppAlreadyHasFirstLaunch: Bool {
+        get { userDefaults.bool(forKey: Keys.launchKey) }
+        set { userDefaults.set(newValue, forKey: Keys.launchKey) }
     }
 }

--- a/Modules/Data/LocalStores/Sources/LocalStores/inMemory/InMemoryToDoLocalDataSource.swift
+++ b/Modules/Data/LocalStores/Sources/LocalStores/inMemory/InMemoryToDoLocalDataSource.swift
@@ -9,7 +9,6 @@
 import Foundation
 import DomainInterface
 import DataInterface
-import Utilities
 import Logging
 
 public final class InMemoryToDoLocalDataSource: ToDoLocalDataSourceProtocol {

--- a/Modules/Data/Networking/Sources/Networking/MockToDoRemoteDataSource.swift
+++ b/Modules/Data/Networking/Sources/Networking/MockToDoRemoteDataSource.swift
@@ -8,7 +8,6 @@
 #if DEBUG
 import Foundation
 import DataInterface
-import Utilities
 import Logging
 
 public final class MockToDoRemoteDataSource: ToDoRemoteDataSourceProtocol {

--- a/Modules/Data/Networking/Tests/NetworkingTests/ToDoRemoteDataSourceContractTests.swift
+++ b/Modules/Data/Networking/Tests/NetworkingTests/ToDoRemoteDataSourceContractTests.swift
@@ -20,7 +20,9 @@ struct ToDoRemoteDataSourceContractTests {
             MockToDoRemoteDataSource()
         ]
 
-        sources.forEach { _ in #expect(true) }
+        sources.forEach { sut in
+            #expect(true)
+        }
     }
 
 
@@ -32,10 +34,10 @@ struct ToDoRemoteDataSourceContractTests {
         ]
 
         for source in sources {
-            let result = try await source.fetchAllToDos()
+            let sut = try await source.fetchAllToDos()
 
-            #expect(!result.todos.isEmpty, "Should return at least one todo")
-            #expect(result.total > 0)
+            #expect(!sut.todos.isEmpty, "Should return at least one todo")
+            #expect(sut.total > 0)
         }
     }
 

--- a/Modules/Data/Repositories/Tests/RepositoriesTests/MockUserDefaultsDataSource.swift
+++ b/Modules/Data/Repositories/Tests/RepositoriesTests/MockUserDefaultsDataSource.swift
@@ -1,0 +1,20 @@
+//
+//  MockUserDefaultsDataSource.swift
+//  Repositories
+//
+//  Created by Sergey Kemenov on 25.02.2026.
+//
+
+import Testing
+@testable import Repositories
+import DataInterface
+
+final class MockUserDefaultsDataSource: UserDefaultsDataSourceProtocol {
+    var isAppAlreadyHasFirstLaunch: Bool
+    var isCoreDataSynced: Bool
+
+    init(isCoreDataSynced: Bool = false, isAppAlreadyHasFirstLaunch: Bool = false) {
+        self.isCoreDataSynced = isCoreDataSynced
+        self.isAppAlreadyHasFirstLaunch = isAppAlreadyHasFirstLaunch
+    }
+}


### PR DESCRIPTION
### User stories
 - [X] #23 
   - For the first launch, remote data loading should start after `ToDoList` screen appears

> [!TIP]
> Should start PR's name with one of the next codes:  
> [US] - user stories  
> [CORE] - core & business logic  
> [BUG] - bug fix  
> [TB] - technical debt    



---

Key information for GitHub Actions:  
Close #23 

    
